### PR TITLE
Move connection string to env var

### DIFF
--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -5,10 +5,16 @@ using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
+string? connectionString = Environment.GetEnvironmentVariable("DEFAULT_CONNECTION");
+if (string.IsNullOrWhiteSpace(connectionString))
+{
+    throw new InvalidOperationException("DEFAULT_CONNECTION environment variable is not set.");
+}
+
 // Add EF Core with MySQL
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseMySql(
-        builder.Configuration.GetConnectionString("DefaultConnection"),
+        connectionString,
         new MySqlServerVersion(new Version(8, 0, 36))
     ));
 

--- a/Backend/appsettings.json
+++ b/Backend/appsettings.json
@@ -5,9 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-
-    "ConnectionStrings": {
-    "DefaultConnection": "server=localhost;database=ea_tracker_db;user=root;password=Hea!90569056;"
-  }
+  "AllowedHosts": "*"
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# ea_Tracker
+
+This project combines an ASP.NET Core backend with a React frontend.
+
+## Connection String Configuration
+
+The backend no longer stores the database connection string in `appsettings.json`.
+Instead, set an environment variable named `DEFAULT_CONNECTION` before running the
+application or building the backend.
+
+Example:
+
+```bash
+export DEFAULT_CONNECTION="server=localhost;database=ea_tracker_db;user=root;password=yourpassword;"
+```
+
+The `Program.cs` file reads this variable at startup and throws an error if it is missing.
+
+## Building
+
+Run the following commands from the project root:
+
+```bash
+cd Backend
+dotnet build
+```
+
+```bash
+cd ../frontend
+npm test
+```
+


### PR DESCRIPTION
## Summary
- remove the connection string from `appsettings.json`
- load `DEFAULT_CONNECTION` environment variable in `Program.cs`
- document the variable in new `README.md`

## Testing
- `dotnet build`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688ab1e7cd7c833285c1d36119b7dfec