### PR TITLE
Load connection string from secret file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ obj/
 
 # VS Code
 .vscode/
+secret.env

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -2,8 +2,11 @@
 using ea_Tracker.Data;
 using ea_Tracker.Services;
 using Microsoft.EntityFrameworkCore;
+using DotNetEnv;
 
 var builder = WebApplication.CreateBuilder(args);
+
+Env.Load("secret.env");
 
 string? connectionString = Environment.GetEnvironmentVariable("DEFAULT_CONNECTION");
 if (string.IsNullOrWhiteSpace(connectionString))

--- a/Backend/ea_Tracker.csproj
+++ b/Backend/ea_Tracker.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.18" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">

--- a/README.md
+++ b/README.md
@@ -5,16 +5,25 @@ This project combines an ASP.NET Core backend with a React frontend.
 ## Connection String Configuration
 
 The backend no longer stores the database connection string in `appsettings.json`.
-Instead, set an environment variable named `DEFAULT_CONNECTION` before running the
-application or building the backend.
+You can provide the `DEFAULT_CONNECTION` value either directly as an environment
+variable or through a `secret.env` file used for local development.
 
-Example:
+Example environment variable:
 
 ```bash
 export DEFAULT_CONNECTION="server=localhost;database=ea_tracker_db;user=root;password=yourpassword;"
 ```
 
-The `Program.cs` file reads this variable at startup and throws an error if it is missing.
+When running locally, create a file named `secret.env` in the repository root
+containing the connection string:
+
+```bash
+DEFAULT_CONNECTION="server=localhost;database=ea_tracker_db;user=root;password=yourpassword;"
+```
+
+`Program.cs` loads this file at startup so the environment variable is available
+automatically. The application will still throw an error if `DEFAULT_CONNECTION`
+is missing after loading the file.
 
 ## Building
 


### PR DESCRIPTION
## Summary
- use DotNetEnv to load variables from `secret.env`
- throw if `DEFAULT_CONNECTION` missing after loading
- ignore `secret.env`
- document creating `secret.env` for local dev

## Testing
- `dotnet build`
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688ab9840d508332875d5668749c0bd3