### PR TITLE
Implement investigator dashboard and setup scripts

### DIFF
--- a/.codex/agents/backend
+++ b/.codex/agents/backend
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/../../Backend" || exit 1
+if [ -f ../secret.env ]; then
+  export $(grep DEFAULT_CONNECTION ../secret.env | xargs) >/dev/null 2>&1 || true
+fi
+if [ -z "$DEFAULT_CONNECTION" ]; then
+  echo "DEFAULT_CONNECTION not set" >&2
+  exit 1
+fi
+dotnet restore
+if [ -d Migrations ] && command -v dotnet-ef >/dev/null 2>&1; then
+  dotnet ef database update
+fi
+dotnet build --nologo
+
+

--- a/.codex/agents/backend.md
+++ b/.codex/agents/backend.md
@@ -10,7 +10,7 @@ This agent ensures quality contributions for the backend architecture, database 
 ## General Workflow
 - Use **feature branches** for all new work. Branch names and commit messages should be clear and descriptive.
 - Run tests and builds before committing:
-  - `dotnet build` from within `Backend/`
+  - Execute `.codex/agents/backend` to restore dependencies, apply migrations, and build the project
   
 ## Backend Guidelines (.NET)
 - **Indentation:** 4 spaces; place opening braces on the next line.

--- a/.codex/agents/frontend
+++ b/.codex/agents/frontend
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/../../frontend" || exit 1
+npm ci --silent
+CI=true npm test --silent -- --passWithNoTests
+

--- a/.codex/agents/frontend.md
+++ b/.codex/agents/frontend.md
@@ -13,7 +13,7 @@ The repository separates server and client code to keep responsibilities clear.
 - Always create feature branches when developing new work. Use descriptive branch names and commit messages to explain the intent of your changes.
 - Before committing, run the project’s tests locally:
 - Before npm start control the backends state, is it okay to start etc. 
-- Run `CI=true npm test --silent -- --passWithNoTests` to validate the frontend build and avoid false failures.
+- Run `.codex/agents/frontend` which installs dependencies and then executes `CI=true npm test --silent -- --passWithNoTests`.
 - Clarify Axios setup
  Axios instance should live:
  Place it in `frontend/src/lib/axios.ts` or a similar shared location. 

--- a/Backend/Controllers/InvestigationsController.cs
+++ b/Backend/Controllers/InvestigationsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using ea_Tracker.Services;
+using System;
 
 namespace ea_Tracker.Controllers
 {
@@ -30,6 +31,44 @@ namespace ea_Tracker.Controllers
         {
             _manager.StartAll();
             return Ok(" Investigators started.");
+        }
+
+        /// <summary>
+        /// Returns all investigators and their IDs.
+        /// </summary>
+        [HttpGet]
+        public IActionResult GetInvestigators()
+        {
+            return Ok(_manager.GetAllInvestigatorStates());
+        }
+
+        /// <summary>
+        /// Starts a specific investigator.
+        /// </summary>
+        [HttpPost("{id}/start")]
+        public IActionResult Start(Guid id)
+        {
+            _manager.StartInvestigator(id);
+            return Ok();
+        }
+
+        /// <summary>
+        /// Stops a specific investigator.
+        /// </summary>
+        [HttpPost("{id}/stop")]
+        public IActionResult Stop(Guid id)
+        {
+            _manager.StopInvestigator(id);
+            return Ok();
+        }
+
+        /// <summary>
+        /// Gets logged results for an investigator.
+        /// </summary>
+        [HttpGet("{id}/results")]
+        public IActionResult Results(Guid id)
+        {
+            return Ok(_manager.GetResults(id));
         }
 
         /// <summary>

--- a/Backend/Models/InvestigatorResult.cs
+++ b/Backend/Models/InvestigatorResult.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace ea_Tracker.Models
+{
+    /// <summary>
+    /// Represents a log entry produced by an investigator.
+    /// </summary>
+    public class InvestigatorResult
+    {
+        /// <summary>
+        /// Gets or sets the identifier of the investigator that generated the entry.
+        /// </summary>
+        public Guid InvestigatorId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timestamp of the log entry.
+        /// </summary>
+        public DateTime Timestamp { get; set; }
+
+        /// <summary>
+        /// Gets or sets a message describing the event.
+        /// </summary>
+        public string? Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets optional payload data for the entry.
+        /// </summary>
+        public string? Payload { get; set; }
+    }
+}
+

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -21,13 +21,9 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
         new MySqlServerVersion(new Version(8, 0, 36))
     ));
 
-// Register InvestigationManager with investigators
-builder.Services.AddSingleton<InvestigationManager>(sp =>
-    new InvestigationManager(new List<Investigator>
-    {
-        new InvoiceInvestigator(),
-        new WaybillInvestigator()
-    }));
+builder.Services.AddScoped<Investigator, InvoiceInvestigator>();
+builder.Services.AddScoped<Investigator, WaybillInvestigator>();
+builder.Services.AddSingleton<InvestigationManager>();
 
 builder.Services.AddCors(options =>
 {

--- a/Backend/Services/Investigator.cs
+++ b/Backend/Services/Investigator.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace ea_Tracker.Services
 {
     /// <summary>
@@ -7,12 +9,17 @@ namespace ea_Tracker.Services
     public abstract class Investigator
     {
         /// <summary>
+        /// Initializes a new unique identifier for the investigator.
+        /// </summary>
+        public Guid Id { get; }
+        /// <summary>
         /// Initializes a new instance of the <see cref="Investigator"/> class.
         /// </summary>
         /// <param name="name">The human readable name of the investigator.</param>
         protected Investigator(string name)
         {
             Name = name;
+            Id = Guid.NewGuid();
         }
 
         /// <summary>

--- a/Backend/Services/InvoiceInvestigator.cs
+++ b/Backend/Services/InvoiceInvestigator.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Linq;
+using ea_Tracker.Data;
+using ea_Tracker.Models;
+
 namespace ea_Tracker.Services
 {
     /// <summary>
@@ -5,11 +10,15 @@ namespace ea_Tracker.Services
     /// </summary>
     public class InvoiceInvestigator : Investigator
     {
+        private readonly ApplicationDbContext _db;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="InvoiceInvestigator"/> class.
         /// </summary>
-        public InvoiceInvestigator() : base("Invoice Investigator")
+        /// <param name="db">The database context.</param>
+        public InvoiceInvestigator(ApplicationDbContext db) : base("Invoice Investigator")
         {
+            _db = db;
         }
 
         /// <summary>
@@ -17,7 +26,16 @@ namespace ea_Tracker.Services
         /// </summary>
         protected override void OnStart()
         {
-            // Add logic here to scan invoices
+            var anomalies = _db.Invoices
+                .Where(i => i.TotalAmount < 0 ||
+                            i.TotalTax > i.TotalAmount * 0.5m ||
+                            i.IssueDate > DateTime.UtcNow)
+                .ToList();
+
+            foreach (var a in anomalies)
+            {
+                Log($"Anomalous invoice {a.Id}");
+            }
         }
 
         /// <summary>

--- a/Backend/Services/WaybillInvestigator.cs
+++ b/Backend/Services/WaybillInvestigator.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Linq;
+using ea_Tracker.Data;
+using ea_Tracker.Models;
+
 namespace ea_Tracker.Services
 {
     /// <summary>
@@ -5,11 +10,15 @@ namespace ea_Tracker.Services
     /// </summary>
     public class WaybillInvestigator : Investigator
     {
+        private readonly ApplicationDbContext _db;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="WaybillInvestigator"/> class.
         /// </summary>
-        public WaybillInvestigator() : base("Waybill Investigator")
+        /// <param name="db">The database context.</param>
+        public WaybillInvestigator(ApplicationDbContext db) : base("Waybill Investigator")
         {
+            _db = db;
         }
 
         /// <summary>
@@ -17,7 +26,15 @@ namespace ea_Tracker.Services
         /// </summary>
         protected override void OnStart()
         {
-            // Add logic here to scan waybills
+            var cutoff = DateTime.UtcNow.AddDays(-7);
+            var late = _db.Waybills
+                .Where(w => w.GoodsIssueDate < cutoff)
+                .ToList();
+
+            foreach (var w in late)
+            {
+                Log($"Late waybill {w.Id}");
+            }
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -30,14 +30,19 @@ is missing after loading the file.
 Run the following commands from the project root:
 
 ```bash
-cd Backend
-dotnet build
+./.codex/agents/backend
 ```
 
 ```bash
-cd ../frontend
-npm test
+./.codex/agents/frontend
 ```
+
+## API Endpoints
+
+- `GET /api/investigations` – list available investigators
+- `POST /api/investigations/{id}/start` – start a single investigator
+- `POST /api/investigations/{id}/stop` – stop a single investigator
+- `GET /api/investigations/{id}/results` – fetch investigation logs
 
 ## Codex Automation
 

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -1,13 +1,35 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import api from "./lib/axios";
 
+interface Investigator {
+  id: string;
+  name: string;
+}
+
+interface LogEntry {
+  timestamp: string;
+  message: string;
+}
+
 function Dashboard(): JSX.Element {
+  const [investigators, setInvestigators] = useState<Investigator[]>([]);
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const loadInvestigators = async (): Promise<void> => {
+    const res = await api.get<Investigator[]>("/api/investigations");
+    setInvestigators(res.data);
+  };
+
+  useEffect(() => {
+    void loadInvestigators();
+  }, []);
+
   const startInvestigators = async (): Promise<void> => {
     try {
       await api.post("/api/investigations/start");
-      alert("🟢 Investigators started!");
+      await loadInvestigators();
     } catch (error) {
-      alert("❌ Failed to start investigators.");
       console.error(error);
     }
   };
@@ -15,20 +37,64 @@ function Dashboard(): JSX.Element {
   const stopInvestigators = async (): Promise<void> => {
     try {
       await api.post("/api/investigations/stop");
-      alert("🔴 Investigators stopped!");
+      await loadInvestigators();
     } catch (error) {
-      alert("❌ Failed to stop investigators.");
       console.error(error);
     }
   };
 
+  const startOne = async (id: string): Promise<void> => {
+    await api.post(`/api/investigations/${id}/start`);
+  };
+
+  const stopOne = async (id: string): Promise<void> => {
+    await api.post(`/api/investigations/${id}/stop`);
+  };
+
+  const select = async (id: string): Promise<void> => {
+    setSelected(id);
+    const res = await api.get<LogEntry[]>(`/api/investigations/${id}/results`);
+    setLogs(res.data);
+  };
+
   return (
-    <div style={{ padding: "2rem", fontFamily: "Arial" }}>
-      <h2>🧠 Intelligent E-Transformation Agent</h2>
-      <button onClick={startInvestigators} style={{ marginRight: "1rem" }}>
-        ▶️ Start Investigators
-      </button>
-      <button onClick={stopInvestigators}>⏹ Stop Investigators</button>
+    <div className="p-8 font-sans">
+      <h2 className="mb-4 text-xl font-bold">Investigators</h2>
+      <div className="mb-4 space-x-2">
+        <button onClick={startInvestigators} className="px-2 py-1 bg-green-600 text-white">Start All</button>
+        <button onClick={stopInvestigators} className="px-2 py-1 bg-red-600 text-white">Stop All</button>
+      </div>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            <th className="border px-2">Id</th>
+            <th className="border px-2">Name</th>
+            <th className="border px-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {investigators.map((inv) => (
+            <tr key={inv.id} className="border" onClick={() => select(inv.id)}>
+              <td className="px-2 border">{inv.id}</td>
+              <td className="px-2 border">{inv.name}</td>
+              <td className="px-2 border space-x-1">
+                <button onClick={() => startOne(inv.id)} className="px-1 bg-green-500 text-white">Start</button>
+                <button onClick={() => stopOne(inv.id)} className="px-1 bg-red-500 text-white">Stop</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {selected && (
+        <div className="mt-4">
+          <h3 className="font-semibold">Logs</h3>
+          <ul className="list-disc ml-4">
+            {logs.map((l, idx) => (
+              <li key={idx}>{l.timestamp} - {l.message}</li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create Codex setup scripts for backend and frontend
- document running scripts in the guidelines and README
- give each `Investigator` a unique `Id`
- add simple `InvestigatorResult` model
- inject `ApplicationDbContext` into investigators and log anomalies
- expand `InvestigationManager` with per-investigator methods
- register investigators through DI in `Program.cs`
- extend controller API for individual investigator control
- update dashboard to list investigators and show logs

## Testing
- `./.codex/agents/backend`
- `./.codex/agents/frontend`

------
https://chatgpt.com/codex/tasks/task_e_688b22a5cbf883329de1c855bf14acd3